### PR TITLE
Report command from tb

### DIFF
--- a/MainServer/include/ChatCommands/Commands/Report.h
+++ b/MainServer/include/ChatCommands/Commands/Report.h
@@ -1,0 +1,140 @@
+#ifndef REPORT_COMPLEXCOMMAND_HEADER
+#define REPORT_COMPLEXCOMMAND_HEADER
+
+#include "../ICommand.h"
+#include "../ChatCommands.h"
+#include "Utils/Utils.h"
+#include "Utils/Constants.h"
+#include "../../MainServer.h"
+#include "../../Classes/ReportManager.h"
+#include <source_location>
+
+namespace Main
+{
+	namespace Command
+	{
+		class Report final : public ICommand
+		{
+		private:
+			std::string m_targetPlayername{};
+			std::string m_reportReason{};
+
+			bool parseCommand(const std::string& providedCommand) override
+			{
+				std::smatch match;
+				if (std::regex_match(providedCommand, match, this->m_pattern))
+				{
+					m_targetPlayername = match[2].str();
+					m_reportReason = match[3].str();
+					return true;
+				}
+				return false;
+			}
+
+		public:
+			Report(const Common::Enums::PlayerGrade requiredGrade)
+				: ICommand{ requiredGrade, "/report <nickname> <reason>"
+				, R"(^(\S+)\s*(\S+)\s*(.*)$)" }
+			{
+			}
+
+			void execute(const std::string& command, std::shared_ptr<Main::Network::Session> session, MN::SessionsManager& sessionsManager,
+				MC::RoomsManager& roomsManager,
+				MP::MainScheduler& scheduler, std::uint32_t roomNumber,
+				Main::MainServer& mainServer) override
+			{
+				START_BENCHMARK
+					if (!parseCommand(command))
+					{
+						session->sendMessage("error: parsing error, see /? for command usage");
+						return;
+					}
+
+				if (m_reportReason.empty())
+				{
+					session->sendMessage("error: report reason cannot be empty");
+					return;
+				}
+
+				if (m_reportReason.size() >= Common::Constants::maxMailboxMessage)
+				{
+					session->sendMessage("error: report reason should be less than 255 characters");
+					return;
+				}
+
+				auto targetSession = sessionsManager.findSessionByName(m_targetPlayername.c_str());
+				if (!targetSession)
+				{
+					session->sendMessage("error: target player not found or not online");
+					return;
+				}
+
+				const auto& reporterInfo = session->getAccountInfo();
+				const auto& targetInfo = targetSession->getAccountInfo();
+
+				Common::Enums::PlayerGrade targetGrade = static_cast<Common::Enums::PlayerGrade>(targetInfo.playerGrade);
+				if (targetGrade == Common::Enums::PlayerGrade::GRADE_ES ||
+					targetGrade == Common::Enums::PlayerGrade::GRADE_MOD ||
+					targetGrade == Common::Enums::PlayerGrade::GRADE_TESTER ||
+					targetGrade == Common::Enums::PlayerGrade::GRADE_GM)
+				{
+					session->sendMessage("error: you cannot report staff members or high-ranking players");
+					return;
+				}
+
+				std::uint32_t currentRoomNumber = session->getPlayer().getRoomNumber();
+				std::string roomInfo = currentRoomNumber > 0 ?
+					"Room ID: " + std::to_string(currentRoomNumber) :
+					"Lobby";
+
+				Main::Structures::ReportInfo reportInfo(
+					0,
+					reporterInfo.accountID,
+					targetInfo.accountID,
+					std::string(reporterInfo.nickname),
+					std::string(targetInfo.nickname),
+					m_reportReason,
+					currentRoomNumber
+				);
+
+				std::uint32_t reportId = mainServer.getReportManager().addReport(reportInfo);
+
+				std::string reportMessage = "[REPORT #" + std::to_string(reportId) + "] " +
+					std::string(reporterInfo.nickname) +
+					" reported " + std::string(targetInfo.nickname) +
+					" in " + roomInfo +
+					". Reason: " + m_reportReason;
+
+				const auto& allSessions = sessionsManager.getAllSessions();
+				std::uint32_t moderatorsNotified = 0;
+
+				for (const auto& sessionPair : allSessions)
+				{
+					auto modSession = sessionPair.second;
+					const auto& modAccountInfo = modSession->getAccountInfo();
+
+					if (modAccountInfo.playerGrade == Common::Enums::PlayerGrade::GRADE_MOD ||
+						modAccountInfo.playerGrade == Common::Enums::PlayerGrade::GRADE_TESTER ||
+						modAccountInfo.playerGrade == Common::Enums::PlayerGrade::GRADE_GM)
+					{
+						modSession->sendMessage(reportMessage, Main::Enums::TIP);
+						modSession->sendMessage("Use /reports to see all reports or /rr " +
+							std::to_string(reportId) + " to acknowledge this report", Main::Enums::INFO);
+						moderatorsNotified++;
+					}
+				}
+
+				session->sendMessage("Report submitted successfully (ID: " + std::to_string(reportId) + ")");
+
+				Utils::Logger::log("REPORT: " + std::string(reporterInfo.nickname) + " -> " +
+					std::string(targetInfo.nickname) + " | Room: " + roomInfo +
+					" | Reason: " + m_reportReason, Utils::LogType::Info, "ReportCommand");
+
+				END_BENCHMARK(Report::execute, session)
+			}
+		};
+
+		REGISTER_CMD(Report, Common::Enums::PlayerGrade::GRADE_NORMAL)
+	}
+}
+#endif

--- a/MainServer/include/ChatCommands/Commands/ReportReceived.h
+++ b/MainServer/include/ChatCommands/Commands/ReportReceived.h
@@ -1,0 +1,114 @@
+#ifndef REPORTRECEIVED_COMPLEXCOMMAND_HEADER
+#define REPORTRECEIVED_COMPLEXCOMMAND_HEADER
+
+#include "../ICommand.h"
+#include "../ChatCommands.h"
+#include "Utils/Utils.h"
+#include "Utils/Constants.h"
+#include "../../MainServer.h"
+#include "../../Classes/ReportManager.h"
+#include "../../Structures/Mailbox.h"
+#include <source_location>
+
+namespace Main
+{
+	namespace Command
+	{
+		class ReportReceived final : public ICommand
+		{
+		private:
+			std::uint32_t m_reportId{};
+
+			bool parseCommand(const std::string& providedCommand) override
+			{
+				std::smatch match;
+				if (std::regex_match(providedCommand, match, this->m_pattern))
+				{
+					const std::string& reportIdStr = match[2].str();
+					auto [ptr, ec] = std::from_chars(reportIdStr.data(), reportIdStr.data() + reportIdStr.size(), m_reportId);
+					if (ec != std::errc{} || ptr != reportIdStr.data() + reportIdStr.size())
+					{
+						return false;
+					}
+					return true;
+				}
+				return false;
+			}
+
+		public:
+			ReportReceived(const Common::Enums::PlayerGrade requiredGrade)
+				: ICommand{ requiredGrade, "/rr <report_id> - Acknowledge a report and thank the reporter"
+				, R"(^(\S+)\s*(\d+)\s*(.*)$)" }
+			{
+			}
+
+			void execute(const std::string& command, std::shared_ptr<Main::Network::Session> session, MN::SessionsManager& sessionsManager,
+				MC::RoomsManager& roomsManager,
+				MP::MainScheduler& scheduler, std::uint32_t roomNumber, Main::MainServer& mainServer) override
+			{
+				START_BENCHMARK
+				if (!parseCommand(command))
+				{
+					session->sendMessage("error: parsing error, see /? for command usage. Usage: /rr <report_id>");
+					return;
+				}
+
+				Main::Structures::ReportInfo report;
+				if (!mainServer.getReportManager().getReportById(m_reportId, report))
+				{
+					session->sendMessage("error: report with ID " + std::to_string(m_reportId) + " not found");
+					return;
+				}
+
+				if (report.isAcknowledged)
+				{
+					session->sendMessage("Report #" + std::to_string(m_reportId) + " was already acknowledged by " +
+						report.acknowledgedBy + " at " + std::string(std::ctime(&report.acknowledgedTime)));
+					return;
+				}
+
+				const auto& modInfo = session->getAccountInfo();
+
+				auto reporterSession = sessionsManager.findSessionByName(report.reporterNickname.c_str());
+
+				if (reporterSession)
+				{
+					std::string thankYouMessage = "Hello " + report.reporterNickname +
+						", Thank you for reporting a player for breaking our rules. We will take appropriate action based on our findings.";
+
+					reporterSession->sendMessage(thankYouMessage, Main::Enums::TIP);
+					session->sendMessage("Thank you message sent to " + report.reporterNickname);
+				}
+				else
+				{
+					Main::Structures::Mailbox mailbox;
+					mailbox.accountId = report.reporterAccountId;
+					mailbox.timestamp = std::time(nullptr);
+					mailbox.hasBeenRead = 0;
+					std::strncpy(mailbox.nickname, modInfo.nickname, sizeof(mailbox.nickname) - 1);
+					mailbox.nickname[sizeof(mailbox.nickname) - 1] = '\0';
+
+					std::string mailboxMessage = "Hello " + report.reporterNickname +
+						", Thank you for reporting a player for breaking our rules. We will take appropriate action based on our findings.";
+
+					std::strncpy(mailbox.message, mailboxMessage.c_str(), sizeof(mailbox.message) - 1);
+					mailbox.message[sizeof(mailbox.message) - 1] = '\0';
+
+					session->sendOfflineMailbox(mailbox);
+					session->sendMessage("Thank you message sent via mailbox to " + report.reporterNickname + " (offline)");
+				}
+
+				mainServer.getReportManager().acknowledgeReport(m_reportId, std::string(modInfo.nickname));
+
+				Utils::Logger::log("REPORT #" + std::to_string(m_reportId) + " ACKNOWLEDGED: " + std::string(modInfo.nickname) +
+					" acknowledged report from " + report.reporterNickname,
+					Utils::LogType::Info, "ReportReceivedCommand");
+
+				END_BENCHMARK(ReportReceived::execute, session)
+			}
+		};
+
+		REGISTER_CMD(ReportReceived, Common::Enums::PlayerGrade::GRADE_MOD)
+	}
+}
+#endif

--- a/MainServer/include/ChatCommands/Commands/Reports.h
+++ b/MainServer/include/ChatCommands/Commands/Reports.h
@@ -1,0 +1,82 @@
+#ifndef REPORTS_COMPLEXCOMMAND_HEADER
+#define REPORTS_COMPLEXCOMMAND_HEADER
+
+#include "../ICommand.h"
+#include "../ChatCommands.h"
+#include "Utils/Utils.h"
+#include "Utils/Constants.h"
+#include "../../MainServer.h"
+#include "../../Classes/ReportManager.h"
+#include <source_location>
+
+namespace Main
+{
+	namespace Command
+	{
+		class Reports final : public ICommand
+		{
+		public:
+			Reports(const Common::Enums::PlayerGrade requiredGrade)
+				: ICommand{ requiredGrade, "/reports - View all pending reports" }
+			{
+			}
+
+			void execute(const std::string& command, std::shared_ptr<Main::Network::Session> session, MN::SessionsManager& sessionsManager,
+				MC::RoomsManager& roomsManager,
+				MP::MainScheduler& scheduler, std::uint32_t roomNumber, Main::MainServer& mainServer) override
+			{
+				START_BENCHMARK
+
+				auto unacknowledgedReports = mainServer.getReportManager().getUnacknowledgedReports();
+				auto totalReports = mainServer.getReportManager().getTotalReportsCount();
+				auto unacknowledgedCount = mainServer.getReportManager().getUnacknowledgedReportsCount();
+
+				if (unacknowledgedReports.empty())
+				{
+					session->sendMessage("No pending reports. Total reports in system: " + std::to_string(totalReports));
+					END_BENCHMARK(Reports::execute, session)
+					return;
+				}
+
+				session->sendMessage("=== PENDING REPORTS (" + std::to_string(unacknowledgedCount) + "/" + std::to_string(totalReports) + ") ===", Main::Enums::TIP);
+
+				for (const auto& report : unacknowledgedReports)
+				{
+					std::string roomInfo = report.roomNumber > 0 ?
+						"Room ID: " + std::to_string(report.roomNumber) :
+						"Lobby";
+
+					std::string timeAgo = "just now";
+					std::time_t now = std::time(nullptr);
+					std::time_t diff = now - report.timestamp;
+
+					if (diff > 60)
+					{
+						std::time_t minutes = diff / 60;
+						if (minutes > 60)
+						{
+							std::time_t hours = minutes / 60;
+							timeAgo = std::to_string(hours) + "h ago";
+						}
+						else
+						{
+							timeAgo = std::to_string(minutes) + "m ago";
+						}
+					}
+
+					session->sendMessage("[" + std::to_string(report.reportId) + "] " +
+						report.reporterNickname + " -> " + report.reportedNickname +
+						" (" + roomInfo + ") - " + timeAgo, Main::Enums::INFO);
+					session->sendMessage("  Reason: " + report.reason, Main::Enums::INFO);
+					session->sendMessage("  Use /rr " + std::to_string(report.reportId) +
+						" to acknowledge this report", Main::Enums::TIP);
+				}
+
+				END_BENCHMARK(Reports::execute, session)
+			}
+		};
+
+		REGISTER_CMD(Reports, Common::Enums::PlayerGrade::GRADE_MOD)
+	}
+}
+#endif

--- a/MainServer/include/Classes/ReportManager.h
+++ b/MainServer/include/Classes/ReportManager.h
@@ -1,0 +1,118 @@
+#ifndef REPORT_MANAGER_H
+#define REPORT_MANAGER_H
+
+#include "../Structures/ReportInfo.h"
+#include <vector>
+#include <mutex>
+#include <memory>
+
+namespace Main
+{
+	namespace Classes
+	{
+		class ReportManager
+		{
+		private:
+			std::vector<Main::Structures::ReportInfo> m_reports;
+			std::uint32_t m_nextReportId{ 1 };
+			std::mutex m_mutex;
+
+		public:
+			ReportManager() = default;
+
+			std::uint32_t addReport(const Main::Structures::ReportInfo& report)
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				auto newReport = report;
+				newReport.reportId = m_nextReportId++;
+				newReport.timestamp = std::time(nullptr);
+				m_reports.push_back(newReport);
+				return newReport.reportId;
+			}
+
+			std::vector<Main::Structures::ReportInfo> getAllReports()
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				return m_reports;
+			}
+
+			std::vector<Main::Structures::ReportInfo> getUnacknowledgedReports()
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				std::vector<Main::Structures::ReportInfo> unacknowledged;
+				for (const auto& report : m_reports)
+				{
+					if (!report.isAcknowledged)
+					{
+						unacknowledged.push_back(report);
+					}
+				}
+				return unacknowledged;
+			}
+
+			bool acknowledgeReport(std::uint32_t reportId, const std::string& acknowledgedBy)
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				for (auto& report : m_reports)
+				{
+					if (report.reportId == reportId)
+					{
+						report.isAcknowledged = true;
+						report.acknowledgedBy = acknowledgedBy;
+						report.acknowledgedTime = std::time(nullptr);
+						return true;
+					}
+				}
+				return false;
+			}
+
+			bool getReportById(std::uint32_t reportId, Main::Structures::ReportInfo& outReport)
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				for (const auto& report : m_reports)
+				{
+					if (report.reportId == reportId)
+					{
+						outReport = report;
+						return true;
+					}
+				}
+				return false;
+			}
+
+			std::size_t getTotalReportsCount()
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				return m_reports.size();
+			}
+
+			std::size_t getUnacknowledgedReportsCount()
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				std::size_t count = 0;
+				for (const auto& report : m_reports)
+				{
+					if (!report.isAcknowledged)
+					{
+						count++;
+					}
+				}
+				return count;
+			}
+
+			void cleanOldReports()
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				std::time_t weekAgo = std::time(nullptr) - (7 * 24 * 60 * 60);
+				m_reports.erase(
+					std::remove_if(m_reports.begin(), m_reports.end(),
+						[weekAgo](const Main::Structures::ReportInfo& report) {
+							return report.timestamp < weekAgo;
+						}),
+					m_reports.end());
+			}
+		};
+	}
+}
+
+#endif

--- a/MainServer/include/Handlers/Player/AuthorizationHandler.h
+++ b/MainServer/include/Handlers/Player/AuthorizationHandler.h
@@ -42,7 +42,8 @@ namespace Main
             std::size_t totalOnlinePlayers,
             bool isServerOffline,
             Main::Persistence::MainScheduler& scheduler,
-            bool isPublic)
+            bool isPublic,
+            Main::Classes::ReportManager& reportManager)
         {
             START_BENCHMARK
 
@@ -102,12 +103,30 @@ namespace Main
                 session->setHasBeenMatchBanned(*hasBeenMatchBannedOpt);
                 session->asyncWrite(response);
                 session->sendMessage("Welcome! To see all commands, type /commands", Main::Enums::ChatExtra::INFO);
-                session->sendMessage(
-                    "Client Version: " +
-                    std::to_string(clientInfo.clientVersion.ver2) + "." +
-                    std::to_string(clientInfo.clientVersion.ver3) + "." +
-                    std::to_string(clientInfo.clientVersion.ver4)
-                );
+
+                Common::Enums::PlayerGrade playerGrade = static_cast<Common::Enums::PlayerGrade>(accountInfoOpt->playerGrade);
+                if (playerGrade == Common::Enums::PlayerGrade::GRADE_MOD ||
+                    playerGrade == Common::Enums::PlayerGrade::GRADE_TESTER ||
+                    playerGrade == Common::Enums::PlayerGrade::GRADE_GM)
+                {
+                    std::size_t pendingReports = reportManager.getUnacknowledgedReportsCount();
+                    if (pendingReports > 0)
+                    {
+                        session->sendMessage("You got " + std::to_string(pendingReports) + " pending reports /reports", Main::Enums::TIP);
+                    }
+                    else
+                    {
+                        session->sendMessage("No pending reports", Main::Enums::TIP);
+                    }
+                }
+
+                
+                    session->sendMessage(
+                        "Client Version: " +
+                        std::to_string(clientInfo.clientVersion.ver2) + "." +
+                        std::to_string(clientInfo.clientVersion.ver3) + "." +
+                        std::to_string(clientInfo.clientVersion.ver4)
+                    );
 
                 END_BENCHMARK(handleAuthorization, session)
                 return *accountInfoOpt;

--- a/MainServer/include/Handlers/Player/InitialPlayerInfoHandlers.h
+++ b/MainServer/include/Handlers/Player/InitialPlayerInfoHandlers.h
@@ -16,13 +16,13 @@ namespace Main
 		inline void handleInitialPlayerInfos(const Common::Network::Packet& request, std::shared_ptr<Main::Network::Session> session,
 			Main::Network::SessionsManager& sessionsManager, Main::Persistence::MainScheduler& scheduler, std::uint64_t timeSinceLastServerRestart,
 			std::uint32_t serverId, bool isServerOffline, bool isPublic, const Main::Structures::EventMissionInfo& eventMissionInfo,
-			const Main::Structures::ExpMpBonusInfo& expMpBonusInfo)
+			const Main::Structures::ExpMpBonusInfo& expMpBonusInfo, Main::Classes::ReportManager& reportManager)
 		{
-			if (auto accountInfo = handleAuthorization(request, session, sessionsManager.getAllSessions().size(), isServerOffline, scheduler, isPublic); accountInfo)
+			if (auto accountInfo = handleAuthorization(request, session, sessionsManager.getAllSessions().size(), isServerOffline, scheduler, isPublic, reportManager); accountInfo)
 			{
 				START_BENCHMARK
 
-				handleAccountInformation(request, session, sessionsManager, scheduler, *accountInfo, timeSinceLastServerRestart, serverId);
+					handleAccountInformation(request, session, sessionsManager, scheduler, *accountInfo, timeSinceLastServerRestart, serverId);
 
 				session->sendInventory(*reinterpret_cast<const std::uint32_t*>(request.getData()));
 

--- a/MainServer/include/MainServer.h
+++ b/MainServer/include/MainServer.h
@@ -16,6 +16,7 @@
 #include <boost/asio.hpp>
 
 #include <AntiCheat/AntiCheat.h>
+#include <Classes/ReportManager.h>
 
 namespace Main
 {

--- a/MainServer/include/MainServer.h
+++ b/MainServer/include/MainServer.h
@@ -42,6 +42,7 @@ namespace Main
 		Main::Classes::RoomsManager m_roomsManager;
 		Main::Classes::ClansManager m_clansManager;
 		Main::Command::ChatCommands m_chatCommands;
+		Main::Classes::ReportManager m_reportManager;
 		std::unordered_map<std::uint32_t, std::function<void(std::shared_ptr<Main::Network::Session>)>> m_generalItemCallbacks;
 		std::unordered_map<std::uint32_t, std::function<void(std::shared_ptr<Main::Network::Session>)>> m_cashItemsCallbacks;
 		std::unordered_map<std::uint32_t, std::function<bool(std::shared_ptr<Main::Network::Session>, const Main::Structures::ItemSerialInfo&,
@@ -73,6 +74,8 @@ namespace Main
 		constexpr void setServerOffline(bool v) { m_isServerOffline = v; }
 		constexpr void setRoomCreationTo(bool v) { m_roomCreationEnabled = v; }
 		constexpr bool getRoomCreation() const noexcept { return m_roomCreationEnabled; };
+		Main::Classes::ReportManager& getReportManager() { return m_reportManager; }
+
 	};
 }
 

--- a/MainServer/include/Structures/ReportInfo.h
+++ b/MainServer/include/Structures/ReportInfo.h
@@ -1,0 +1,45 @@
+#ifndef REPORT_INFO_H
+#define REPORT_INFO_H
+
+#include <cstdint>
+#include <string>
+#include <ctime>
+
+namespace Main
+{
+	namespace Structures
+	{
+		struct ReportInfo
+		{
+			std::uint32_t reportId{};
+			std::uint32_t reporterAccountId{};
+			std::uint32_t reportedAccountId{};
+			std::string reporterNickname{};
+			std::string reportedNickname{};
+			std::string reason{};
+			std::uint32_t roomNumber{};
+			std::time_t timestamp{};
+			bool isAcknowledged{ false };
+			std::string acknowledgedBy{};
+			std::time_t acknowledgedTime{};
+
+			ReportInfo() = default;
+
+			ReportInfo(std::uint32_t id, std::uint32_t reporterId, std::uint32_t reportedId,
+					  const std::string& reporterName, const std::string& reportedName,
+					  const std::string& reportReason, std::uint32_t roomNum)
+				: reportId(id)
+				, reporterAccountId(reporterId)
+				, reportedAccountId(reportedId)
+				, reporterNickname(reporterName)
+				, reportedNickname(reportedName)
+				, reason(reportReason)
+				, roomNumber(roomNum)
+				, timestamp(std::time(nullptr))
+			{
+			}
+		};
+	}
+}
+
+#endif

--- a/MainServer/src/GeneratedCommands.cpp
+++ b/MainServer/src/GeneratedCommands.cpp
@@ -30,3 +30,6 @@
 #include "../include/ChatCommands/Commands/Shutdown.h"
 #include "../include/ChatCommands/Commands/TestCommand.h"
 #include "../include/ChatCommands/Commands/Unban.h"
+#include "../include/ChatCommands/Commands/Report.h"
+#include "../include/ChatCommands/Commands/ReportReceived.h"
+#include "../include/ChatCommands/Commands/Reports.h"

--- a/MainServer/src/MainServer.cpp
+++ b/MainServer/src/MainServer.cpp
@@ -167,9 +167,11 @@ namespace Main
 			std::shared_ptr<Main::Network::Session> session) { Main::Handlers::handleMailboxGiftSend(request, session, m_serverId); });
 		CN::Session::addCallback<CN::PacketType::ENCRYPTED, MN::Session>(67, [&](const Common::Network::Packet& request,
 			std::shared_ptr<Main::Network::Session>  session) { session->displayGiftboxes(static_cast<Main::Enums::MailboxMission>(request.getMission())); });
-		CN::Session::addCallback<CN::PacketType::ENCRYPTED, MN::Session>(68, [&](const Common::Network::Packet& request, 
-			std::shared_ptr<Main::Network::Session> session) { Main::Handlers::handleInitialPlayerInfos(request, session, m_sessionsManager, m_scheduler, m_timeSinceLastRestart,
-				m_serverId, m_isServerOffline, m_isPublic, m_eventMissionInfo, m_expMpEvent); });
+		CN::Session::addCallback<CN::PacketType::ENCRYPTED, MN::Session>(68, [&](const Common::Network::Packet& request,
+			std::shared_ptr<Main::Network::Session> session) {
+				Main::Handlers::handleInitialPlayerInfos(request, session, m_sessionsManager, m_scheduler, m_timeSinceLastRestart,
+					m_serverId, m_isServerOffline, m_isPublic, m_eventMissionInfo, m_expMpEvent, m_reportManager);
+			});
 		CN::Session::addCallback<CN::PacketType::ENCRYPTED, MN::Session>(71, [&](const Common::Network::Packet& request,
 			std::shared_ptr<Main::Network::Session> session) { Main::Handlers::handlePing(request, session, m_roomsManager, Details::parseData<Main::ClientData::Ping>(request), m_scheduler); });
 


### PR DESCRIPTION
For All Players:
/report <nickname> <reason>
Submit a report against another player
Generates unique report ID for tracking
Notifies all online moderators (grades 3, 4, 7)
Usage: /report Hacker123 Cheating in game

For Moderators Only:
/reports
View all pending (unacknowledged) reports
Shows report details including ID, players, room, reason, and time
Displays relative time (e.g., "2h ago", "5m ago")
Usage: /reports

/reportreceived <report_id>
Acknowledge a specific report by ID
Sends thank you message to reporter (online or offline via mailbox)
Marks report as acknowledged with moderator info
Usage: /reportreceived 42

Report Flow:
Player submits report with /report <player> <reason>
System assigns unique ID and stores report
All online moderators receive instant notification
Moderators can view all reports with /reports
Moderators acknowledge reports with /reportreceived <id>
Reporter receives thank you message (immediate if online, mailbox if offline)