### PR TITLE
Fix ping instability caused by ghost sessions remaining in CastServer…

### DIFF
--- a/CastServer/include/Handlers/PlayerPositionHandler.h
+++ b/CastServer/include/Handlers/PlayerPositionHandler.h
@@ -54,7 +54,7 @@ namespace Cast
                 acManager.submitEvent(std::make_unique<Ac::PacketFloodingEvent>(session, 20, 1000, "Speed hack (Cheat Engine)", 281));
             }
 
-            static Common::Network::UnecryptedPacket response{ 1440, 322, 1 };
+            Common::Network::UnecryptedPacket response{ 1440, 322, 1 };
             response.setCommand(322, 0, 0, 1);
             const auto fullSize = request.getFullSize();
             

--- a/CastServer/include/Handlers/PlayerPositionHandler.h
+++ b/CastServer/include/Handlers/PlayerPositionHandler.h
@@ -54,7 +54,7 @@ namespace Cast
                 acManager.submitEvent(std::make_unique<Ac::PacketFloodingEvent>(session, 20, 1000, "Speed hack (Cheat Engine)", 281));
             }
 
-            Common::Network::UnecryptedPacket response{ 1440, 322, 1 };
+            static Common::Network::UnecryptedPacket response{ 1440, 322, 1 };
             response.setCommand(322, 0, 0, 1);
             const auto fullSize = request.getFullSize();
             

--- a/CastServer/src/Classes/Room.cpp
+++ b/CastServer/src/Classes/Room.cpp
@@ -103,11 +103,8 @@ namespace Cast
 
 			auto it = std::remove_if(m_playersVec.begin(), m_playersVec.end(),
 				[&](const std::weak_ptr<Cast::Network::Session>& weakSession) {
-					if (auto session = weakSession.lock()) 
-					{
-						return session->getId() == playerSession->getId();
-					}
-					return false; 
+					auto session = weakSession.lock();
+					return !session || session->getId() == playerSession->getId();
 				});
 
 			if (it != m_playersVec.end())

--- a/CastServer/src/Network/SessionsManager.cpp
+++ b/CastServer/src/Network/SessionsManager.cpp
@@ -32,6 +32,8 @@ namespace Cast
 			{
 				m_sessionsBySessionId[sessionId]->setIsInMatch(false);
 				m_sessionsBySessionId.erase(sessionId);
+				if (m_roomsManager)
+					m_roomsManager->removePlayerFromRoom(sessionId);
 			}
 		}
 

--- a/Common/include/Network/Session.h
+++ b/Common/include/Network/Session.h
@@ -107,12 +107,15 @@ namespace Common
 			virtual ~Session()
 			{
 				closeSocket();
-				sessionIdManager.releaseSessionID(m_id);
 			}
 
 			void setSessionId(std::size_t id)
 			{
-				m_id = id;
+				if (m_id != id)
+				{
+					sessionIdManager.releaseSessionID(m_id);
+					m_id = id;
+				}
 			}
 
 			void setAccountId(std::uint32_t accountId)


### PR DESCRIPTION
… rooms

When a player's TCP connection dropped mid-game, removeSession only erased them from the sessions map but left their weak_ptr in the room's m_playersVec. On reconnect (common after a wrong-password delay within the 10s heartbeat window), the new session joined alongside the ghost. Position broadcasts went to both. The ghost's still-open TCP socket caused ASIO completion handler backlog on the event loop, delaying pong (order 72) responses — high ping while alive, recovering while dead.

Fixes:
- CastServer SessionsManager::removeSession now calls removePlayerFromRoom so players are evicted from rooms immediately on disconnect
- Room::addPlayer lambda also removes expired weak_ptrs (was returning false for them, causing stale entries to accumulate forever)
- Session::setSessionId releases the old pool ID before setting the new one, preventing CastServer session ID pool exhaustion after 500 connections
- Session destructor no longer calls releaseSessionID explicitly; closeSocket already handles this (was a triple-release)
- Removed static from PlayerPositionHandler response packet; std::move on a static left it in moved-from state on every subsequent call